### PR TITLE
Output the help block text for select elements

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -237,30 +237,30 @@ $(function(){
 
 
            function cleanUpJsonEdit() {
-                   // hide spinner
-                   $('#app_settings_schema .spinner').hide();
+               // hide spinner
+               $('#app_settings_schema .spinner').hide();
 
-                   // make html more boostrap compatible
-                   $('#app_settings_schema .je-field').addClass('control-group');
+               // make html more boostrap compatible
+               $('#app_settings_schema .je-field').addClass('control-group');
 
-                   // move title/field description to div for better UX
-                   $('#app_settings_schema .je-field').each(function(idx, el) {
-                       var $input = $(el).children('input'),
-                           text;
-                       // top level .je-field element has no input child
-                       if ($input.length === 0) {
-                           return;
-                       }
-                       text = $input.attr('title');
-                       // no description property on json schema, skip
-                       if (!text) {
-                           return;
-                       }
-                       $input.parent().append(
-                           '<div class="help-block">' +  text + '</div>'
-                       );
-                       $input.removeAttr('title');
-                   });
+               // move title/field description to div for better UX
+               $('#app_settings_schema .je-field').each(function(idx, el) {
+                   var $input = $(el).children('input, select'),
+                       text;
+                   // top level .je-field element has no input child
+                   if ($input.length === 0) {
+                       return;
+                   }
+                   text = $input.attr('title');
+                   // no description property on json schema, skip
+                   if (!text) {
+                       return;
+                   }
+                   $input.parent().append(
+                       '<div class="help-block">' +  text + '</div>'
+                   );
+                   $input.removeAttr('title');
+               });
            }
 
 


### PR DESCRIPTION
Other than the whitespace change, include "select" in the jquery selector so dropdowns have any help text rendered.

Issue: #52 #53 
