### PR TITLE
Fix for bad css for object descriptions. medic/medic-webapp#2473

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -307,6 +307,13 @@ $(function(){
                 for (var i = 0; i < tagnames.length; i++) {
                     cleanUpJsonEditTitle(tagnames[i]);
                 }
+                // Same for objects.
+                setTimeout(function() {
+                    $('#app_settings_schema .je-object-fields > legend')
+                        .each(function() {
+                            $(this).replaceWith($('<div class="help-block">' + this.innerHTML + '</div>'));
+                        });
+                }, 0);
             }
 
             /**


### PR DESCRIPTION
When adding descriptions on the app_settings schema for objects, they got displayed in huge font because of a wrong html tag.
